### PR TITLE
Sync the license file with the main spec's repo

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
 All documents in this Repository are licensed by contributors
 under the 
-[W3C Document License](https://www.w3.org/Consortium/Legal/copyright-documents).
+[W3C Software and Document License](https://www.w3.org/Consortium/Legal/copyright-software).
 


### PR DESCRIPTION
The main document (as indeed almost all specifications these days) is published under the software and document license of W3C, and that is also what respec generates into the document by default. For some reasons (bug?) the W3C process generates the W3C document license file. I propose to synch that file with the main document's repo and with what the note is published in... 